### PR TITLE
Fix: Exclude tasks from trashed projects and headings

### DIFF
--- a/thingies/cli.py
+++ b/thingies/cli.py
@@ -108,9 +108,12 @@ def list(ctx, status, area, project, tag, today):
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
             LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
+            LEFT JOIN TMTask h ON t.heading = h.uuid
+            LEFT JOIN TMTask hp ON h.project = hp.uuid AND hp.type = 1
             LEFT JOIN TMTaskTag tt ON t.uuid = tt.tasks
             LEFT JOIN TMTag tag ON tt.tags = tag.uuid
-            WHERE t.type = 0 AND t.trashed = 0
+            WHERE t.type = 0 AND t.trashed = 0 
+                AND (h.uuid IS NULL OR hp.uuid IS NULL OR hp.trashed = 0)
         """
 
         conditions = []
@@ -347,7 +350,11 @@ def search(ctx, search_term, in_notes):
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
             LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
-            WHERE t.trashed = 0 AND (
+            LEFT JOIN TMTask h ON t.heading = h.uuid
+            LEFT JOIN TMTask hp ON h.project = hp.uuid AND hp.type = 1
+            WHERE t.trashed = 0 
+                AND (h.uuid IS NULL OR hp.uuid IS NULL OR hp.trashed = 0)
+                AND (
                 LOWER(t.title) LIKE LOWER(?)
         """
 

--- a/thingies/cli.py
+++ b/thingies/cli.py
@@ -107,7 +107,7 @@ def list(ctx, status, area, project, tag, today):
                 GROUP_CONCAT(tag.title, ', ') as tags
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
-            LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1
+            LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
             LEFT JOIN TMTaskTag tt ON t.uuid = tt.tasks
             LEFT JOIN TMTag tag ON tt.tags = tag.uuid
             WHERE t.type = 0 AND t.trashed = 0
@@ -346,7 +346,7 @@ def search(ctx, search_term, in_notes):
                 a.title as area_name
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
-            LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1
+            LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
             WHERE t.trashed = 0 AND (
                 LOWER(t.title) LIKE LOWER(?)
         """

--- a/thingies/cli.py
+++ b/thingies/cli.py
@@ -108,11 +108,13 @@ def list(ctx, status, area, project, tag, today):
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
             LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
+            LEFT JOIN TMTask p2 ON t.project = p2.uuid AND p2.type = 1
             LEFT JOIN TMTask h ON t.heading = h.uuid
             LEFT JOIN TMTask hp ON h.project = hp.uuid AND hp.type = 1
             LEFT JOIN TMTaskTag tt ON t.uuid = tt.tasks
             LEFT JOIN TMTag tag ON tt.tags = tag.uuid
             WHERE t.type = 0 AND t.trashed = 0 
+                AND (t.project IS NULL OR p2.trashed = 0)
                 AND (h.uuid IS NULL OR hp.uuid IS NULL OR hp.trashed = 0)
         """
 
@@ -350,9 +352,11 @@ def search(ctx, search_term, in_notes):
             FROM TMTask t
             LEFT JOIN TMArea a ON t.area = a.uuid
             LEFT JOIN TMTask p ON t.project = p.uuid AND p.type = 1 AND p.trashed = 0
+            LEFT JOIN TMTask p2 ON t.project = p2.uuid AND p2.type = 1
             LEFT JOIN TMTask h ON t.heading = h.uuid
             LEFT JOIN TMTask hp ON h.project = hp.uuid AND hp.type = 1
             WHERE t.trashed = 0 
+                AND (t.project IS NULL OR p2.trashed = 0)
                 AND (h.uuid IS NULL OR hp.uuid IS NULL OR hp.trashed = 0)
                 AND (
                 LOWER(t.title) LIKE LOWER(?)

--- a/thingies/config.py
+++ b/thingies/config.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 ROOT_PATH = Path(__file__).parent.parent
 
-# DB_PATH = (
-#     Path.home()
-#     / "Library"
-#     / "Group Containers"
-#     / "JLMPQHK86H.com.culturedcode.ThingsMac"
-# )
+DB_PATH = (
+    Path.home()
+    / "Library"
+    / "Group Containers"
+    / "JLMPQHK86H.com.culturedcode.ThingsMac"
+)
 
-DB_PATH = ROOT_PATH / "data" / "things3_db_copy.sqlite"
+# DB_PATH = ROOT_PATH / "data" / "things3_db_copy.sqlite"


### PR DESCRIPTION
## Summary
- Fixed bug where tasks from trashed projects were still appearing in list and search results
- Added proper filtering for tasks under headings that belong to trashed projects
- Restored correct DB_PATH configuration to use actual Things3 database

## Test plan
- [x] Verify tasks in trashed projects are excluded from `thingies list`
- [x] Verify tasks under headings in trashed projects are excluded
- [x] Verify search results don't include tasks from trashed projects
- [x] Confirm normal tasks and projects still display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)