### PR TITLE
resolve short UUID prefixes in all commands

### DIFF
--- a/internal/cmd/projects/complete.go
+++ b/internal/cmd/projects/complete.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"thingies/internal/cmd/shared"
+	"thingies/internal/db"
 	"thingies/internal/things"
 )
 
@@ -16,7 +18,16 @@ var completeCmd = &cobra.Command{
 }
 
 func runComplete(cmd *cobra.Command, args []string) error {
-	uuid := args[0]
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveProjectUUID(args[0])
+	if err != nil {
+		return err
+	}
 
 	if err := things.CompleteProject(uuid); err != nil {
 		return fmt.Errorf("failed to complete project: %w", err)

--- a/internal/cmd/projects/delete.go
+++ b/internal/cmd/projects/delete.go
@@ -27,17 +27,19 @@ func init() {
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
-	uuid := args[0]
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveProjectUUID(args[0])
+	if err != nil {
+		return err
+	}
 
 	if !deleteForce {
-		thingsDB, err := db.Open(shared.GetDBPath(cmd))
-		if err != nil {
-			return err
-		}
-
 		project, err := thingsDB.GetProject(uuid)
-		thingsDB.Close()
-
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/projects/update.go
+++ b/internal/cmd/projects/update.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"thingies/internal/cmd/shared"
+	"thingies/internal/db"
 	"thingies/internal/things"
 )
 
@@ -30,8 +32,19 @@ func init() {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveProjectUUID(args[0])
+	if err != nil {
+		return err
+	}
+
 	params := things.ProjectUpdateParams{
-		UUID:     args[0],
+		UUID:     uuid,
 		Name:     updateTitle,
 		Notes:    updateNotes,
 		DueDate:  updateDeadline,
@@ -42,6 +55,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update project: %w", err)
 	}
 
-	fmt.Printf("Updated project: %s\n", args[0])
+	fmt.Printf("Updated project: %s\n", uuid)
 	return nil
 }

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	searchInNotes      bool
+	searchInNotes       bool
 	searchIncludeFuture bool
 )
 

--- a/internal/cmd/tags/create.go
+++ b/internal/cmd/tags/create.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"thingies/internal/cmd/shared"
+	"thingies/internal/db"
 	"thingies/internal/things"
 )
 
@@ -22,6 +24,21 @@ func init() {
 
 func runCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
+
+	// Resolve parent tag UUID if provided
+	if parentTag != "" {
+		thingsDB, err := db.Open(shared.GetDBPath(cmd))
+		if err != nil {
+			return err
+		}
+		defer thingsDB.Close()
+
+		resolved, err := thingsDB.ResolveTagUUID(parentTag)
+		if err != nil {
+			return err
+		}
+		parentTag = resolved
+	}
 
 	uuid, err := things.CreateTag(name, parentTag)
 	if err != nil {

--- a/internal/cmd/tasks/cancel.go
+++ b/internal/cmd/tasks/cancel.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"thingies/internal/cmd/shared"
+	"thingies/internal/db"
 	"thingies/internal/things"
 )
 
@@ -16,7 +18,16 @@ var cancelCmd = &cobra.Command{
 }
 
 func runCancel(cmd *cobra.Command, args []string) error {
-	uuid := args[0]
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveTaskUUID(args[0])
+	if err != nil {
+		return err
+	}
 
 	if err := things.CancelTask(uuid); err != nil {
 		return fmt.Errorf("failed to cancel task: %w", err)

--- a/internal/cmd/tasks/complete.go
+++ b/internal/cmd/tasks/complete.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"thingies/internal/cmd/shared"
+	"thingies/internal/db"
 	"thingies/internal/things"
 )
 
@@ -16,10 +18,21 @@ var completeCmd = &cobra.Command{
 }
 
 func runComplete(cmd *cobra.Command, args []string) error {
-	if err := things.CompleteTask(args[0]); err != nil {
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveTaskUUID(args[0])
+	if err != nil {
+		return err
+	}
+
+	if err := things.CompleteTask(uuid); err != nil {
 		return fmt.Errorf("failed to complete task: %w", err)
 	}
 
-	fmt.Printf("Completed task: %s\n", args[0])
+	fmt.Printf("Completed task: %s\n", uuid)
 	return nil
 }

--- a/internal/cmd/tasks/delete.go
+++ b/internal/cmd/tasks/delete.go
@@ -27,18 +27,20 @@ func init() {
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
-	uuid := args[0]
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveTaskUUID(args[0])
+	if err != nil {
+		return err
+	}
 
 	// Get task info for confirmation
 	if !deleteForce {
-		thingsDB, err := db.Open(shared.GetDBPath(cmd))
-		if err != nil {
-			return err
-		}
-
 		task, err := thingsDB.GetTask(uuid)
-		thingsDB.Close()
-
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/tasks/update.go
+++ b/internal/cmd/tasks/update.go
@@ -34,8 +34,19 @@ func init() {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
+	thingsDB, err := db.Open(shared.GetDBPath(cmd))
+	if err != nil {
+		return err
+	}
+	defer thingsDB.Close()
+
+	uuid, err := thingsDB.ResolveTaskUUID(args[0])
+	if err != nil {
+		return err
+	}
+
 	params := things.TaskUpdateParams{
-		UUID:     args[0],
+		UUID:     uuid,
 		Name:     updateTitle,
 		Notes:    updateNotes,
 		When:     updateWhen,
@@ -45,12 +56,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Specific dates need an auth token for the URL scheme
 	if things.IsSpecificDate(updateWhen) {
-		thingsDB, err := db.Open(shared.GetDBPath(cmd))
-		if err != nil {
-			return fmt.Errorf("failed to open database for auth token: %w", err)
-		}
-		defer thingsDB.Close()
-
 		token, err := thingsDB.GetAuthToken()
 		if err != nil {
 			return fmt.Errorf("failed to get auth token: %w", err)
@@ -62,6 +67,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update task: %w", err)
 	}
 
-	fmt.Printf("Updated task: %s\n", args[0])
+	fmt.Printf("Updated task: %s\n", uuid)
 	return nil
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -67,7 +67,7 @@ func (db *ThingsDB) ListTasks(filter TaskFilter) ([]models.Task, error) {
 		conditions = append(conditions, "t.status = 3")
 	case "canceled":
 		conditions = append(conditions, "t.status = 2")
-	// "all" - no filter
+		// "all" - no filter
 	}
 
 	// Today filter based on things.py logic:
@@ -897,66 +897,93 @@ func (db *ThingsDB) GetLogbook(limit int) ([]models.Task, error) {
 	return scanTasks(rows)
 }
 
-// ResolveTaskUUID resolves a short UUID prefix to a full task UUID
+// ResolveTaskUUID resolves a short UUID prefix to a full task UUID.
+// If the input is already a full UUID (22 chars), it's returned as-is after verification.
 func (db *ThingsDB) ResolveTaskUUID(prefix string) (string, error) {
+	if len(prefix) >= 22 {
+		// Full UUID, verify it exists
+		var exists int
+		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 0`, prefix).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("task not found: %s", prefix)
+		}
+		return prefix, nil
+	}
+
 	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 0`
-	rows, err := db.conn.Query(query, prefix)
-	if err != nil {
-		return "", fmt.Errorf("failed to query task: %w", err)
-	}
-	defer rows.Close()
-
-	var uuids []string
-	for rows.Next() {
-		var uuid string
-		if err := rows.Scan(&uuid); err != nil {
-			return "", err
-		}
-		uuids = append(uuids, uuid)
-	}
-
-	if len(uuids) == 0 {
-		return "", fmt.Errorf("task not found: %s", prefix)
-	}
-	if len(uuids) > 1 {
-		return "", fmt.Errorf("ambiguous task prefix '%s' matches %d tasks", prefix, len(uuids))
-	}
-	return uuids[0], nil
+	return resolvePrefix(db, query, prefix, "task")
 }
 
-// ResolveAreaUUID resolves a short UUID prefix to a full area UUID
+// ResolveProjectUUID resolves a short UUID prefix to a full project UUID.
+// If the input is already a full UUID (22 chars), it's returned as-is after verification.
+func (db *ThingsDB) ResolveProjectUUID(prefix string) (string, error) {
+	if len(prefix) >= 22 {
+		var exists int
+		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0`, prefix).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("project not found: %s", prefix)
+		}
+		return prefix, nil
+	}
+
+	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 1 AND trashed = 0`
+	return resolvePrefix(db, query, prefix, "project")
+}
+
+// ResolveAreaUUID resolves a short UUID prefix to a full area UUID.
+// If the input is already a full UUID (22 chars), it's returned as-is after verification.
 func (db *ThingsDB) ResolveAreaUUID(prefix string) (string, error) {
-	query := `SELECT uuid FROM TMArea WHERE uuid LIKE ? || '%'`
-	rows, err := db.conn.Query(query, prefix)
-	if err != nil {
-		return "", fmt.Errorf("failed to query area: %w", err)
-	}
-	defer rows.Close()
-
-	var uuids []string
-	for rows.Next() {
-		var uuid string
-		if err := rows.Scan(&uuid); err != nil {
-			return "", err
+	if len(prefix) >= 22 {
+		var exists int
+		err := db.conn.QueryRow(`SELECT 1 FROM TMArea WHERE uuid = ?`, prefix).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("area not found: %s", prefix)
 		}
-		uuids = append(uuids, uuid)
+		return prefix, nil
 	}
 
-	if len(uuids) == 0 {
-		return "", fmt.Errorf("area not found: %s", prefix)
-	}
-	if len(uuids) > 1 {
-		return "", fmt.Errorf("ambiguous area prefix '%s' matches %d areas", prefix, len(uuids))
-	}
-	return uuids[0], nil
+	query := `SELECT uuid FROM TMArea WHERE uuid LIKE ? || '%'`
+	return resolvePrefix(db, query, prefix, "area")
 }
 
-// ResolveTagUUID resolves a short UUID prefix to a full tag UUID
+// ResolveTagUUID resolves a short UUID prefix to a full tag UUID.
+// If the input is already a full UUID (22 chars), it's returned as-is after verification.
 func (db *ThingsDB) ResolveTagUUID(prefix string) (string, error) {
+	if len(prefix) >= 22 {
+		var exists int
+		err := db.conn.QueryRow(`SELECT 1 FROM TMTag WHERE uuid = ?`, prefix).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("tag not found: %s", prefix)
+		}
+		return prefix, nil
+	}
+
 	query := `SELECT uuid FROM TMTag WHERE uuid LIKE ? || '%'`
+	return resolvePrefix(db, query, prefix, "tag")
+}
+
+// ResolveHeadingUUID resolves a short UUID prefix to a full heading UUID.
+// If the input is already a full UUID (22 chars), it's returned as-is after verification.
+func (db *ThingsDB) ResolveHeadingUUID(prefix string) (string, error) {
+	if len(prefix) >= 22 {
+		var exists int
+		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 2`, prefix).Scan(&exists)
+		if err != nil {
+			return "", fmt.Errorf("heading not found: %s", prefix)
+		}
+		return prefix, nil
+	}
+
+	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 2`
+	return resolvePrefix(db, query, prefix, "heading")
+}
+
+// resolvePrefix is a shared helper for resolving a short UUID prefix to a full UUID.
+// The query must select UUIDs with a single ? placeholder for the prefix.
+func resolvePrefix(db *ThingsDB, query, prefix, entityType string) (string, error) {
 	rows, err := db.conn.Query(query, prefix)
 	if err != nil {
-		return "", fmt.Errorf("failed to query tag: %w", err)
+		return "", fmt.Errorf("failed to query %s: %w", entityType, err)
 	}
 	defer rows.Close()
 
@@ -970,10 +997,10 @@ func (db *ThingsDB) ResolveTagUUID(prefix string) (string, error) {
 	}
 
 	if len(uuids) == 0 {
-		return "", fmt.Errorf("tag not found: %s", prefix)
+		return "", fmt.Errorf("%s not found: %s", entityType, prefix)
 	}
 	if len(uuids) > 1 {
-		return "", fmt.Errorf("ambiguous tag prefix '%s' matches %d tags", prefix, len(uuids))
+		return "", fmt.Errorf("ambiguous %s prefix '%s' matches %d %ss", entityType, prefix, len(uuids), entityType)
 	}
 	return uuids[0], nil
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3,11 +3,15 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"thingies/internal/models"
 )
+
+// prefixPattern matches valid UUID prefix characters (alphanumeric only)
+var prefixPattern = regexp.MustCompile(`^[0-9A-Za-z]+$`)
 
 // TaskFilter contains filters for listing tasks
 type TaskFilter struct {
@@ -904,13 +908,16 @@ func (db *ThingsDB) ResolveTaskUUID(prefix string) (string, error) {
 		// Full UUID, verify it exists
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 0`, prefix).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("task not found: %s", prefix)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query task: %w", err)
 		}
 		return prefix, nil
 	}
 
-	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 0`
+	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 0 LIMIT 2`
 	return resolvePrefix(db, query, prefix, "task")
 }
 
@@ -920,13 +927,16 @@ func (db *ThingsDB) ResolveProjectUUID(prefix string) (string, error) {
 	if len(prefix) >= 22 {
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0`, prefix).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("project not found: %s", prefix)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query project: %w", err)
 		}
 		return prefix, nil
 	}
 
-	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 1 AND trashed = 0`
+	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 1 AND trashed = 0 LIMIT 2`
 	return resolvePrefix(db, query, prefix, "project")
 }
 
@@ -936,13 +946,16 @@ func (db *ThingsDB) ResolveAreaUUID(prefix string) (string, error) {
 	if len(prefix) >= 22 {
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMArea WHERE uuid = ?`, prefix).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("area not found: %s", prefix)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query area: %w", err)
 		}
 		return prefix, nil
 	}
 
-	query := `SELECT uuid FROM TMArea WHERE uuid LIKE ? || '%'`
+	query := `SELECT uuid FROM TMArea WHERE uuid LIKE ? || '%' LIMIT 2`
 	return resolvePrefix(db, query, prefix, "area")
 }
 
@@ -952,13 +965,16 @@ func (db *ThingsDB) ResolveTagUUID(prefix string) (string, error) {
 	if len(prefix) >= 22 {
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMTag WHERE uuid = ?`, prefix).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("tag not found: %s", prefix)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query tag: %w", err)
 		}
 		return prefix, nil
 	}
 
-	query := `SELECT uuid FROM TMTag WHERE uuid LIKE ? || '%'`
+	query := `SELECT uuid FROM TMTag WHERE uuid LIKE ? || '%' LIMIT 2`
 	return resolvePrefix(db, query, prefix, "tag")
 }
 
@@ -968,19 +984,29 @@ func (db *ThingsDB) ResolveHeadingUUID(prefix string) (string, error) {
 	if len(prefix) >= 22 {
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 2`, prefix).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("heading not found: %s", prefix)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query heading: %w", err)
 		}
 		return prefix, nil
 	}
 
-	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 2`
+	query := `SELECT uuid FROM TMTask WHERE uuid LIKE ? || '%' AND type = 2 LIMIT 2`
 	return resolvePrefix(db, query, prefix, "heading")
 }
 
 // resolvePrefix is a shared helper for resolving a short UUID prefix to a full UUID.
 // The query must select UUIDs with a single ? placeholder for the prefix.
 func resolvePrefix(db *ThingsDB, query, prefix, entityType string) (string, error) {
+	if prefix == "" {
+		return "", fmt.Errorf("%s prefix cannot be empty", entityType)
+	}
+	if !prefixPattern.MatchString(prefix) {
+		return "", fmt.Errorf("invalid %s prefix: %s (must be alphanumeric)", entityType, prefix)
+	}
+
 	rows, err := db.conn.Query(query, prefix)
 	if err != nil {
 		return "", fmt.Errorf("failed to query %s: %w", entityType, err)
@@ -994,6 +1020,9 @@ func resolvePrefix(db *ThingsDB, query, prefix, entityType string) (string, erro
 			return "", err
 		}
 		uuids = append(uuids, uuid)
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("failed to iterate %s results: %w", entityType, err)
 	}
 
 	if len(uuids) == 0 {

--- a/internal/db/resolve.go
+++ b/internal/db/resolve.go
@@ -5,11 +5,10 @@ import (
 	"regexp"
 )
 
-// uuidPattern matches Things UUIDs: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX (36 chars with dashes)
-var uuidPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+// uuidPattern matches Things UUIDs: 22-character base62 alphanumeric strings
+var uuidPattern = regexp.MustCompile(`^[0-9A-Za-z]{22}$`)
 
-// LooksLikeUUID checks if string appears to be a UUID
-// Things UUIDs are 36 chars with dashes: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+// LooksLikeUUID checks if string appears to be a full Things UUID (22 alphanumeric chars)
 func LooksLikeUUID(s string) bool {
 	return uuidPattern.MatchString(s)
 }
@@ -76,9 +75,8 @@ func (db *ThingsDB) GetAreaUUIDByName(name string) (string, error) {
 	return uuids[0], nil
 }
 
-// ResolveProjectID returns UUID for a project given name or UUID
-// If the input looks like a UUID, it's returned as-is (after validation)
-// Otherwise, it's looked up by name
+// ResolveProjectID returns UUID for a project given name, full UUID, or short UUID prefix.
+// Tries in order: full UUID match, short UUID prefix, name lookup.
 func (db *ThingsDB) ResolveProjectID(nameOrUUID string) (string, error) {
 	if LooksLikeUUID(nameOrUUID) {
 		// Verify the UUID exists
@@ -89,12 +87,18 @@ func (db *ThingsDB) ResolveProjectID(nameOrUUID string) (string, error) {
 		}
 		return nameOrUUID, nil
 	}
+
+	// Try short UUID prefix resolution first
+	if resolved, err := db.ResolveProjectUUID(nameOrUUID); err == nil {
+		return resolved, nil
+	}
+
+	// Fall back to name lookup
 	return db.GetProjectUUIDByName(nameOrUUID)
 }
 
-// ResolveAreaID returns UUID for an area given name or UUID
-// If the input looks like a UUID, it's returned as-is (after validation)
-// Otherwise, it's looked up by name
+// ResolveAreaID returns UUID for an area given name, full UUID, or short UUID prefix.
+// Tries in order: full UUID match, short UUID prefix, name lookup.
 func (db *ThingsDB) ResolveAreaID(nameOrUUID string) (string, error) {
 	if LooksLikeUUID(nameOrUUID) {
 		// Verify the UUID exists
@@ -105,5 +109,12 @@ func (db *ThingsDB) ResolveAreaID(nameOrUUID string) (string, error) {
 		}
 		return nameOrUUID, nil
 	}
+
+	// Try short UUID prefix resolution first
+	if resolved, err := db.ResolveAreaUUID(nameOrUUID); err == nil {
+		return resolved, nil
+	}
+
+	// Fall back to name lookup
 	return db.GetAreaUUIDByName(nameOrUUID)
 }

--- a/internal/db/resolve.go
+++ b/internal/db/resolve.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // uuidPattern matches Things UUIDs: 22-character base62 alphanumeric strings
@@ -82,15 +84,24 @@ func (db *ThingsDB) ResolveProjectID(nameOrUUID string) (string, error) {
 		// Verify the UUID exists
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0`, nameOrUUID).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("project not found: %s", nameOrUUID)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query project: %w", err)
 		}
 		return nameOrUUID, nil
 	}
 
 	// Try short UUID prefix resolution first
-	if resolved, err := db.ResolveProjectUUID(nameOrUUID); err == nil {
+	resolved, err := db.ResolveProjectUUID(nameOrUUID)
+	if err == nil {
 		return resolved, nil
+	}
+	// Only fall through to name lookup for "not found" errors;
+	// surface ambiguous prefix and DB errors immediately
+	if !strings.Contains(err.Error(), "not found") {
+		return "", err
 	}
 
 	// Fall back to name lookup
@@ -104,15 +115,24 @@ func (db *ThingsDB) ResolveAreaID(nameOrUUID string) (string, error) {
 		// Verify the UUID exists
 		var exists int
 		err := db.conn.QueryRow(`SELECT 1 FROM TMArea WHERE uuid = ?`, nameOrUUID).Scan(&exists)
-		if err != nil {
+		if err == sql.ErrNoRows {
 			return "", fmt.Errorf("area not found: %s", nameOrUUID)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to query area: %w", err)
 		}
 		return nameOrUUID, nil
 	}
 
 	// Try short UUID prefix resolution first
-	if resolved, err := db.ResolveAreaUUID(nameOrUUID); err == nil {
+	resolved, err := db.ResolveAreaUUID(nameOrUUID)
+	if err == nil {
 		return resolved, nil
+	}
+	// Only fall through to name lookup for "not found" errors;
+	// surface ambiguous prefix and DB errors immediately
+	if !strings.Contains(err.Error(), "not found") {
+		return "", err
 	}
 
 	// Fall back to name lookup

--- a/internal/db/scanner.go
+++ b/internal/db/scanner.go
@@ -113,9 +113,9 @@ func thingsDateToNullTime(ts sql.NullFloat64) sql.NullTime {
 	packed := int(ts.Float64)
 
 	// Extract year, month, day from packed bits
-	year := (packed & 0x7FF0000) >> 16  // bits 16-26
-	month := (packed & 0xF000) >> 12    // bits 12-15
-	day := (packed & 0xF80) >> 7        // bits 7-11
+	year := (packed & 0x7FF0000) >> 16 // bits 16-26
+	month := (packed & 0xF000) >> 12   // bits 12-15
+	day := (packed & 0xF80) >> 7       // bits 7-11
 
 	return sql.NullTime{
 		Time:  time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC),

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -4,13 +4,13 @@ import "database/sql"
 
 // Project represents a Things 3 project
 type Project struct {
-	UUID         string         `json:"uuid"`
-	Title        string         `json:"title"`
-	Notes        sql.NullString `json:"notes,omitempty"`
-	Status       TaskStatus     `json:"status"`
-	AreaName     sql.NullString `json:"area_name,omitempty"`
-	OpenTasks    int            `json:"open_tasks"`
-	TotalTasks   int            `json:"total_tasks"`
+	UUID       string         `json:"uuid"`
+	Title      string         `json:"title"`
+	Notes      sql.NullString `json:"notes,omitempty"`
+	Status     TaskStatus     `json:"status"`
+	AreaName   sql.NullString `json:"area_name,omitempty"`
+	OpenTasks  int            `json:"open_tasks"`
+	TotalTasks int            `json:"total_tasks"`
 }
 
 // ProjectJSON is the JSON-serializable version of Project

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -7,22 +7,22 @@ import (
 
 // Task represents a Things 3 task
 type Task struct {
-	UUID        string         `json:"uuid"`
-	Title       string         `json:"title"`
-	Notes       sql.NullString `json:"notes,omitempty"`
-	Status      TaskStatus     `json:"status"`
-	Type        TaskType       `json:"type"`
-	Created     sql.NullTime   `json:"created,omitempty"`
-	Modified    sql.NullTime   `json:"modified,omitempty"`
-	Scheduled   sql.NullTime   `json:"scheduled,omitempty"`
-	Deadline    sql.NullTime   `json:"due,omitempty"`
-	Completed   sql.NullTime   `json:"completed,omitempty"`
-	AreaName    sql.NullString `json:"area_name,omitempty"`
-	ProjectUUID sql.NullString `json:"project_uuid,omitempty"`
-	ProjectName sql.NullString `json:"project_name,omitempty"`
-	HeadingUUID sql.NullString `json:"heading_uuid,omitempty"`
-	HeadingName sql.NullString `json:"heading_name,omitempty"`
-	Tags        sql.NullString `json:"tags,omitempty"`
+	UUID           string          `json:"uuid"`
+	Title          string          `json:"title"`
+	Notes          sql.NullString  `json:"notes,omitempty"`
+	Status         TaskStatus      `json:"status"`
+	Type           TaskType        `json:"type"`
+	Created        sql.NullTime    `json:"created,omitempty"`
+	Modified       sql.NullTime    `json:"modified,omitempty"`
+	Scheduled      sql.NullTime    `json:"scheduled,omitempty"`
+	Deadline       sql.NullTime    `json:"due,omitempty"`
+	Completed      sql.NullTime    `json:"completed,omitempty"`
+	AreaName       sql.NullString  `json:"area_name,omitempty"`
+	ProjectUUID    sql.NullString  `json:"project_uuid,omitempty"`
+	ProjectName    sql.NullString  `json:"project_name,omitempty"`
+	HeadingUUID    sql.NullString  `json:"heading_uuid,omitempty"`
+	HeadingName    sql.NullString  `json:"heading_name,omitempty"`
+	Tags           sql.NullString  `json:"tags,omitempty"`
 	IsRepeating    bool            `json:"is_repeating"`
 	TodayIndex     sql.NullInt64   `json:"today_index,omitempty"`
 	ChecklistItems []ChecklistItem `json:"checklist_items,omitempty"`
@@ -30,21 +30,21 @@ type Task struct {
 
 // TaskJSON is the JSON-serializable version of Task
 type TaskJSON struct {
-	UUID        string `json:"uuid"`
-	Title       string `json:"title"`
-	Notes       string `json:"notes,omitempty"`
-	Status      string `json:"status"`
-	Type        string `json:"type"`
-	Created     string `json:"created,omitempty"`
-	Modified    string `json:"modified,omitempty"`
-	Scheduled   string `json:"scheduled,omitempty"`
-	Due         string `json:"due,omitempty"`
-	Completed   string `json:"completed,omitempty"`
-	AreaName    string `json:"area_name,omitempty"`
-	ProjectUUID string `json:"project_uuid,omitempty"`
-	ProjectName string `json:"project_name,omitempty"`
-	HeadingUUID string `json:"heading_uuid,omitempty"`
-	HeadingName string `json:"heading_name,omitempty"`
+	UUID           string          `json:"uuid"`
+	Title          string          `json:"title"`
+	Notes          string          `json:"notes,omitempty"`
+	Status         string          `json:"status"`
+	Type           string          `json:"type"`
+	Created        string          `json:"created,omitempty"`
+	Modified       string          `json:"modified,omitempty"`
+	Scheduled      string          `json:"scheduled,omitempty"`
+	Due            string          `json:"due,omitempty"`
+	Completed      string          `json:"completed,omitempty"`
+	AreaName       string          `json:"area_name,omitempty"`
+	ProjectUUID    string          `json:"project_uuid,omitempty"`
+	ProjectName    string          `json:"project_name,omitempty"`
+	HeadingUUID    string          `json:"heading_uuid,omitempty"`
+	HeadingName    string          `json:"heading_name,omitempty"`
 	Tags           string          `json:"tags,omitempty"`
 	IsRepeating    bool            `json:"is_repeating"`
 	ChecklistItems []ChecklistItem `json:"checklist_items,omitempty"`
@@ -53,21 +53,21 @@ type TaskJSON struct {
 // ToJSON converts Task to its JSON-serializable form
 func (t *Task) ToJSON() TaskJSON {
 	return TaskJSON{
-		UUID:        t.UUID,
-		Title:       t.Title,
-		Notes:       nullString(t.Notes),
-		Status:      t.Status.String(),
-		Type:        t.Type.String(),
-		Created:     formatTime(t.Created),
-		Modified:    formatTime(t.Modified),
-		Scheduled:   formatTime(t.Scheduled),
-		Due:         formatTime(t.Deadline),
-		Completed:   formatTime(t.Completed),
-		AreaName:    nullString(t.AreaName),
-		ProjectUUID: nullString(t.ProjectUUID),
-		ProjectName: nullString(t.ProjectName),
-		HeadingUUID: nullString(t.HeadingUUID),
-		HeadingName: nullString(t.HeadingName),
+		UUID:           t.UUID,
+		Title:          t.Title,
+		Notes:          nullString(t.Notes),
+		Status:         t.Status.String(),
+		Type:           t.Type.String(),
+		Created:        formatTime(t.Created),
+		Modified:       formatTime(t.Modified),
+		Scheduled:      formatTime(t.Scheduled),
+		Due:            formatTime(t.Deadline),
+		Completed:      formatTime(t.Completed),
+		AreaName:       nullString(t.AreaName),
+		ProjectUUID:    nullString(t.ProjectUUID),
+		ProjectName:    nullString(t.ProjectName),
+		HeadingUUID:    nullString(t.HeadingUUID),
+		HeadingName:    nullString(t.HeadingName),
 		Tags:           nullString(t.Tags),
 		IsRepeating:    t.IsRepeating,
 		ChecklistItems: t.ChecklistItems,

--- a/internal/server/handlers_tasks.go
+++ b/internal/server/handlers_tasks.go
@@ -39,7 +39,13 @@ func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := s.db.GetTask(uuid)
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	task, err := s.db.GetTask(resolved)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			s.writeError(w, http.StatusNotFound, err.Error())

--- a/internal/server/headings.go
+++ b/internal/server/headings.go
@@ -20,6 +20,13 @@ func (s *Server) handleDeleteHeading(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveHeadingUUID(uuid)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	if err := things.DeleteHeading(uuid); err != nil {
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -39,6 +46,13 @@ func (s *Server) handleUpdateHeading(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "missing uuid")
 		return
 	}
+
+	resolved, err := s.db.ResolveHeadingUUID(uuid)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
 
 	var req headingUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,9 +206,15 @@ func (s *Server) handleGetProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, err := s.db.GetProject(uuid)
+	resolved, err := s.db.ResolveProjectUUID(uuid)
 	if err != nil {
-		if err.Error() == fmt.Sprintf("project not found: %s", uuid) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	project, err := s.db.GetProject(resolved)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
@@ -227,6 +233,13 @@ func (s *Server) handleGetProjectTasks(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "uuid required", http.StatusBadRequest)
 		return
 	}
+
+	resolved, err := s.db.ResolveProjectUUID(uuid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	uuid = resolved
 
 	includeCompleted := r.URL.Query().Get("include-completed") == "true"
 
@@ -253,6 +266,13 @@ func (s *Server) handleGetProjectHeadings(w http.ResponseWriter, r *http.Request
 		http.Error(w, "uuid required", http.StatusBadRequest)
 		return
 	}
+
+	resolved, err := s.db.ResolveProjectUUID(uuid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	uuid = resolved
 
 	headings, err := s.db.GetProjectHeadings(uuid)
 	if err != nil {
@@ -545,7 +565,13 @@ func (s *Server) handleGetArea(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	area, err := s.db.GetArea(uuid)
+	resolved, err := s.db.ResolveAreaUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	area, err := s.db.GetArea(resolved)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			writeError(w, http.StatusNotFound, err.Error())
@@ -566,8 +592,15 @@ func (s *Server) handleGetAreaTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveAreaUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	// Check if area exists first
-	_, err := s.db.GetArea(uuid)
+	_, err = s.db.GetArea(uuid)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			writeError(w, http.StatusNotFound, err.Error())
@@ -595,8 +628,15 @@ func (s *Server) handleGetAreaProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveAreaUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	// Check if area exists first
-	_, err := s.db.GetArea(uuid)
+	_, err = s.db.GetArea(uuid)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			writeError(w, http.StatusNotFound, err.Error())

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -101,6 +101,13 @@ func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	var req TaskUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
@@ -142,6 +149,13 @@ func (s *Server) handleCompleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	if err := things.CompleteTask(uuid); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to complete task: "+err.Error())
 		return
@@ -157,6 +171,13 @@ func (s *Server) handleCancelTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "task UUID is required")
 		return
 	}
+
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
 
 	if err := things.CancelTask(uuid); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to cancel task: "+err.Error())
@@ -174,6 +195,13 @@ func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	if err := things.DeleteTask(uuid); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete task: "+err.Error())
 		return
@@ -190,6 +218,13 @@ func (s *Server) handleMoveTaskToToday(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
+
 	if err := things.MoveTaskToToday(uuid); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to move task to today: "+err.Error())
 		return
@@ -205,6 +240,13 @@ func (s *Server) handleMoveTaskToSomeday(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "task UUID is required")
 		return
 	}
+
+	resolved, err := s.db.ResolveTaskUUID(uuid)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	uuid = resolved
 
 	// Use UpdateTask with When="someday" which moves to the Someday list
 	params := things.TaskUpdateParams{

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -7,15 +7,15 @@ import (
 
 // AddParams contains parameters for creating a task
 type AddParams struct {
-	Title     string
-	Notes     string
-	When      string
-	Deadline  string
-	Tags      string
-	List      string
-	Heading   string
-	Completed bool
-	Canceled  bool
+	Title          string
+	Notes          string
+	When           string
+	Deadline       string
+	Tags           string
+	List           string
+	Heading        string
+	Completed      bool
+	Canceled       bool
 	ChecklistItems []string
 }
 


### PR DESCRIPTION
users see truncated 8-char UUIDs in list output but action commands 
(complete, delete, update, cancel) need full UUIDs for AppleScript/URL scheme.
now you can copy-paste the short ID from any list view and use it directly.

**what changed:**

- fixed `LooksLikeUUID` to recognize Things' actual 22-char base62 UUIDs 
  (was matching hex UUIDs that Things never uses)
- added `ResolveProjectUUID` and `ResolveHeadingUUID` alongside existing 
  task/area/tag resolvers
- extracted shared `resolvePrefix` helper to DRY up the resolve functions
- all resolve functions now handle full UUIDs (skip to verification) 
  and short prefixes (LIKE query)
- `ResolveProjectID` and `ResolveAreaID` now try short prefix before name lookup
- wired resolution into: tasks complete/cancel/delete/update, projects 
  complete/delete/update, tags create --parent
- wired resolution into all REST API handlers that take UUID path params
- also includes `go fmt` cleanup on a few files with pre-existing alignment issues