### PR TITLE
remove delete prompts, reject unknown API fields

### DIFF
--- a/internal/cmd/areas/delete.go
+++ b/internal/cmd/areas/delete.go
@@ -1,18 +1,13 @@
 package areas
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"thingies/internal/cmd/shared"
 	"thingies/internal/db"
 	"thingies/internal/things"
 )
-
-var forceDelete bool
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete <uuid>",
@@ -21,14 +16,9 @@ var deleteCmd = &cobra.Command{
 	RunE:  runDelete,
 }
 
-func init() {
-	deleteCmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "Skip confirmation")
-}
-
 func runDelete(cmd *cobra.Command, args []string) error {
 	uuid := args[0]
 
-	// Resolve short UUID if needed
 	thingsDB, err := db.Open(shared.GetDBPath(cmd))
 	if err != nil {
 		return err
@@ -40,21 +30,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get area details for confirmation
 	area, err := thingsDB.GetArea(fullUUID)
 	if err != nil {
 		return err
-	}
-
-	if !forceDelete {
-		fmt.Printf("Delete area '%s'? This will NOT delete tasks/projects in the area. [y/N] ", area.Title)
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(strings.ToLower(response))
-		if response != "y" && response != "yes" {
-			fmt.Println("Canceled")
-			return nil
-		}
 	}
 
 	if err := things.DeleteArea(fullUUID); err != nil {

--- a/internal/cmd/areas/delete_test.go
+++ b/internal/cmd/areas/delete_test.go
@@ -1,0 +1,51 @@
+package areas
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestDeleteNoStdinRead verifies that the areas delete command does not read
+// from os.Stdin (i.e., no interactive confirmation prompt). This test parses
+// the source file using go/ast and fails if it finds references to os.Stdin
+// or the bufio package.
+func TestDeleteNoStdinRead(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "delete.go", nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "os" && sel.Sel.Name == "Stdin" {
+			t.Errorf("delete.go must not reference os.Stdin (found at %s)", fset.Position(n.Pos()))
+		}
+		return true
+	})
+
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"bufio"` {
+			t.Errorf("delete.go must not import bufio (found at %s)", fset.Position(imp.Pos()))
+		}
+	}
+}
+
+// TestDeleteNoForceFlag verifies that the --force flag is removed or not
+// registered on the delete command, since delete should execute without
+// prompting.
+func TestDeleteNoForceFlag(t *testing.T) {
+	flag := deleteCmd.Flags().Lookup("force")
+	if flag != nil {
+		t.Errorf("delete command should not have a --force flag; confirmation prompts should be removed entirely")
+	}
+}

--- a/internal/cmd/projects/delete.go
+++ b/internal/cmd/projects/delete.go
@@ -1,10 +1,7 @@
 package projects
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"thingies/internal/cmd/shared"
@@ -12,18 +9,12 @@ import (
 	"thingies/internal/things"
 )
 
-var deleteForce bool
-
 var deleteCmd = &cobra.Command{
 	Use:   "delete <uuid>",
 	Short: "Delete a project",
 	Long:  `Delete (trash) a project using AppleScript.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runDelete,
-}
-
-func init() {
-	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
@@ -36,25 +27,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	uuid, err := thingsDB.ResolveProjectUUID(args[0])
 	if err != nil {
 		return err
-	}
-
-	if !deleteForce {
-		project, err := thingsDB.GetProject(uuid)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Delete project: %s (%d tasks)\n", project.Title, project.TotalTasks)
-		fmt.Print("Are you sure? [y/N] ")
-
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(strings.ToLower(response))
-
-		if response != "y" && response != "yes" {
-			fmt.Println("Canceled")
-			return nil
-		}
 	}
 
 	if err := things.DeleteProject(uuid); err != nil {

--- a/internal/cmd/projects/delete_test.go
+++ b/internal/cmd/projects/delete_test.go
@@ -1,0 +1,58 @@
+package projects
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestDeleteNoStdinRead ensures runDelete does not read from os.Stdin.
+// The delete command should execute without interactive confirmation.
+func TestDeleteNoStdinRead(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "delete.go", nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "os" && sel.Sel.Name == "Stdin" {
+			t.Errorf("delete.go must not reference os.Stdin — delete should not prompt for confirmation")
+		}
+		return true
+	})
+}
+
+// TestDeleteNoBufioImport ensures delete.go does not import "bufio",
+// since there is no need for interactive input.
+func TestDeleteNoBufioImport(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "delete.go", nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"bufio"` {
+			t.Errorf("delete.go must not import bufio — delete should not prompt for confirmation")
+		}
+	}
+}
+
+// TestDeleteNoForceFlag ensures the --force flag is not registered,
+// since delete should execute unconditionally.
+func TestDeleteNoForceFlag(t *testing.T) {
+	flag := deleteCmd.Flags().Lookup("force")
+	if flag != nil {
+		t.Errorf("delete command should not have a --force flag — delete should execute without confirmation")
+	}
+}

--- a/internal/cmd/tags/delete.go
+++ b/internal/cmd/tags/delete.go
@@ -1,18 +1,13 @@
 package tags
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"thingies/internal/cmd/shared"
 	"thingies/internal/db"
 	"thingies/internal/things"
 )
-
-var forceDelete bool
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete <uuid>",
@@ -21,14 +16,9 @@ var deleteCmd = &cobra.Command{
 	RunE:  runDelete,
 }
 
-func init() {
-	deleteCmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "Skip confirmation")
-}
-
 func runDelete(cmd *cobra.Command, args []string) error {
 	uuid := args[0]
 
-	// Resolve short UUID if needed
 	thingsDB, err := db.Open(shared.GetDBPath(cmd))
 	if err != nil {
 		return err
@@ -40,21 +30,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get tag details for confirmation
 	tag, err := thingsDB.GetTag(fullUUID)
 	if err != nil {
 		return err
-	}
-
-	if !forceDelete {
-		fmt.Printf("Delete tag '%s'? This will remove the tag from all tasks. [y/N] ", tag.Title)
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(strings.ToLower(response))
-		if response != "y" && response != "yes" {
-			fmt.Println("Canceled")
-			return nil
-		}
 	}
 
 	if err := things.DeleteTag(fullUUID); err != nil {

--- a/internal/cmd/tags/delete_test.go
+++ b/internal/cmd/tags/delete_test.go
@@ -1,0 +1,68 @@
+package tags
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// parseDeleteFile parses delete.go in the same directory as this test file.
+func parseDeleteFile(t *testing.T) *ast.File {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	deleteFile := filepath.Join(filepath.Dir(thisFile), "delete.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, deleteFile, nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+	return f
+}
+
+func TestDeleteDoesNotUseStdin(t *testing.T) {
+	f := parseDeleteFile(t)
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "os" && sel.Sel.Name == "Stdin" {
+			t.Error("delete.go must not reference os.Stdin — delete should execute without interactive confirmation")
+		}
+		return true
+	})
+}
+
+func TestDeleteDoesNotUseBufio(t *testing.T) {
+	f := parseDeleteFile(t)
+
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == "bufio" {
+			t.Error("delete.go must not import bufio — delete should execute without interactive confirmation")
+		}
+	}
+}
+
+func TestDeleteForceFlag(t *testing.T) {
+	// The --force flag should not exist or should be a deprecated no-op.
+	// Check that init() does not register a "force" flag.
+	cmd := deleteCmd
+	flag := cmd.Flags().Lookup("force")
+	if flag != nil {
+		t.Error("delete command should not have a --force flag — delete should always execute without confirmation")
+	}
+}

--- a/internal/cmd/tasks/delete.go
+++ b/internal/cmd/tasks/delete.go
@@ -1,10 +1,7 @@
 package tasks
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"thingies/internal/cmd/shared"
@@ -12,18 +9,12 @@ import (
 	"thingies/internal/things"
 )
 
-var deleteForce bool
-
 var deleteCmd = &cobra.Command{
 	Use:   "delete <uuid>",
 	Short: "Delete a task",
 	Long:  `Delete (trash) a task using AppleScript.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runDelete,
-}
-
-func init() {
-	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
@@ -36,26 +27,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	uuid, err := thingsDB.ResolveTaskUUID(args[0])
 	if err != nil {
 		return err
-	}
-
-	// Get task info for confirmation
-	if !deleteForce {
-		task, err := thingsDB.GetTask(uuid)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Delete task: %s\n", task.Title)
-		fmt.Print("Are you sure? [y/N] ")
-
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(strings.ToLower(response))
-
-		if response != "y" && response != "yes" {
-			fmt.Println("Canceled")
-			return nil
-		}
 	}
 
 	if err := things.DeleteTask(uuid); err != nil {

--- a/internal/cmd/tasks/delete_test.go
+++ b/internal/cmd/tasks/delete_test.go
@@ -1,0 +1,83 @@
+package tasks
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDeleteNoStdinRead verifies that runDelete does not read from os.Stdin.
+// The delete command should execute without interactive confirmation.
+// This test parses the source file and checks for references to os.Stdin and bufio,
+// which would indicate an interactive prompt.
+func TestDeleteNoStdinRead(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+
+	deleteFile := filepath.Join(filepath.Dir(thisFile), "delete.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, deleteFile, nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+
+	var stdinRefs []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		// Flag os.Stdin references
+		if ident.Name == "os" && sel.Sel.Name == "Stdin" {
+			pos := fset.Position(n.Pos())
+			stdinRefs = append(stdinRefs, pos.String())
+		}
+		return true
+	})
+
+	if len(stdinRefs) > 0 {
+		t.Errorf("delete.go must not reference os.Stdin (found at %v); delete should not prompt for confirmation", stdinRefs)
+	}
+}
+
+// TestDeleteNoBufioImport verifies that delete.go does not import "bufio",
+// which would indicate interactive stdin reading for confirmation prompts.
+func TestDeleteNoBufioImport(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+
+	deleteFile := filepath.Join(filepath.Dir(thisFile), "delete.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, deleteFile, nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("failed to parse delete.go: %v", err)
+	}
+
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"bufio"` {
+			t.Errorf("delete.go must not import \"bufio\"; delete should not prompt for confirmation")
+		}
+	}
+}
+
+// TestDeleteNoForceFlag verifies that the --force flag has been removed.
+// Since delete no longer prompts, --force is unnecessary.
+func TestDeleteNoForceFlag(t *testing.T) {
+	flag := deleteCmd.Flags().Lookup("force")
+	if flag != nil {
+		t.Error("delete command should not have a --force flag; confirmation prompts have been removed")
+	}
+}

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -64,7 +64,9 @@ func writeSuccess(w http.ResponseWriter, message string) {
 // handleCreateTask handles POST /tasks
 func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	var req TaskCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}

--- a/internal/server/tasks_create_test.go
+++ b/internal/server/tasks_create_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestCreateTaskRejectsUnknownFields verifies that POST /tasks returns 400
+// when the request body contains fields not in TaskCreateRequest.
+// Currently FAILS because json.Decoder silently ignores unknown fields.
+func TestCreateTaskRejectsUnknownFields(t *testing.T) {
+	s := &Server{}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "unknown field 'scheduled'",
+			body: `{"title": "test task", "scheduled": "today"}`,
+		},
+		{
+			name: "misspelled 'titel'",
+			body: `{"titel": "test task"}`,
+		},
+		{
+			name: "misspelled 'tag' instead of 'tags'",
+			body: `{"title": "test task", "tag": "urgent"}`,
+		},
+		{
+			name: "unknown field 'priority'",
+			body: `{"title": "test task", "priority": "high"}`,
+		},
+		{
+			name: "multiple unknown fields",
+			body: `{"title": "test task", "foo": "bar", "baz": 123}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			s.handleCreateTask(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d; body: %s", w.Code, w.Body.String())
+			}
+
+			// Response should mention the unknown field
+			body := w.Body.String()
+			if !strings.Contains(body, "unknown") && !strings.Contains(body, "unrecognized") {
+				t.Errorf("expected error message about unknown/unrecognized field, got: %s", body)
+			}
+		})
+	}
+}
+
+// TestCreateTaskAcceptsValidFields verifies that POST /tasks does NOT reject
+// a request that only contains known fields. We don't need Things to actually
+// create the task — we just verify the handler doesn't return 400 for valid input.
+func TestCreateTaskAcceptsValidFields(t *testing.T) {
+	s := &Server{}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "title only",
+			body: `{"title": "test task"}`,
+		},
+		{
+			name: "all valid fields",
+			body: `{"title": "test", "notes": "some notes", "when": "today", "deadline": "2026-03-01", "tags": "urgent", "list": "Work", "heading": "Section"}`,
+		},
+		{
+			name: "subset of optional fields",
+			body: `{"title": "test", "when": "tomorrow", "tags": "quick"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			s.handleCreateTask(w, req)
+
+			// Should NOT be 400 — any other status means the body was accepted.
+			// It may fail later (e.g., 500 because Things isn't running), but
+			// the point is it shouldn't be rejected as invalid input.
+			if w.Code == http.StatusBadRequest {
+				t.Errorf("valid fields should not be rejected, got 400; body: %s", w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/server/tasks_create_test.go
+++ b/internal/server/tasks_create_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,12 +61,11 @@ func TestCreateTaskRejectsUnknownFields(t *testing.T) {
 	}
 }
 
-// TestCreateTaskAcceptsValidFields verifies that POST /tasks does NOT reject
-// a request that only contains known fields. We don't need Things to actually
-// create the task — we just verify the handler doesn't return 400 for valid input.
+// TestCreateTaskAcceptsValidFields verifies that valid JSON fields decode
+// without error when DisallowUnknownFields is enabled. This tests the decode
+// path directly to avoid side effects (the handler calls things.OpenURL which
+// launches external apps).
 func TestCreateTaskAcceptsValidFields(t *testing.T) {
-	s := &Server{}
-
 	tests := []struct {
 		name string
 		body string
@@ -86,17 +86,11 @@ func TestCreateTaskAcceptsValidFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(tt.body))
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
-
-			s.handleCreateTask(w, req)
-
-			// Should NOT be 400 — any other status means the body was accepted.
-			// It may fail later (e.g., 500 because Things isn't running), but
-			// the point is it shouldn't be rejected as invalid input.
-			if w.Code == http.StatusBadRequest {
-				t.Errorf("valid fields should not be rejected, got 400; body: %s", w.Body.String())
+			decoder := json.NewDecoder(strings.NewReader(tt.body))
+			decoder.DisallowUnknownFields()
+			var req TaskCreateRequest
+			if err := decoder.Decode(&req); err != nil {
+				t.Errorf("valid fields should decode without error, got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
removes interactive confirmation prompts from all four delete commands
(tasks, projects, areas, tags) and adds `DisallowUnknownFields()` to
`POST /tasks` so the API rejects misspelled or bogus JSON fields
instead of silently ignoring them.

the delete commands were blocking on stdin with "Are you sure? [y/N]"
which made them unusable from scripts and AI agents. the `--force` flags
have been removed entirely since there's nothing to force anymore.

the unknown fields fix was prompted by signalbot's claude sending
`"scheduled": "today"` instead of `"when": "today"` and getting a 200
back with no date set on the task.

all changes have TDD-style tests (AST-based for the delete commands,
httptest for the server). the test for valid field acceptance decodes
JSON directly to avoid launching Things via `open`.

codex review came back clean after fixing one non-hermetic test.
